### PR TITLE
Fix default end in SmartBuffer.fill

### DIFF
--- a/packages/smartbuffer/src/index.ts
+++ b/packages/smartbuffer/src/index.ts
@@ -2018,10 +2018,7 @@ export class SmartBuffer {
     if (_isString(value) && value.length > 0) {
       value = value.charCodeAt(0);
     }
-    let lend =
-      end === void 0
-        ? this.buffer.length // ??? may be woffset
-        : end;
+    let lend = end === void 0 ? this.woffset : end;
 
     if (!this.noAssert) {
       if (typeof value !== 'number' || value % 1 !== 0) {

--- a/packages/smartbuffer/test/index.spec.ts
+++ b/packages/smartbuffer/test/index.spec.ts
@@ -194,6 +194,17 @@ describe('SmartBuffer', () => {
       expect(bb.capacity).toEqual(21);
     });
 
+    it('fill without args does not extend write offset', () => {
+      const bb = new SmartBuffer(4);
+      bb.fill(0);
+      expect(bb.woffset).toEqual(0);
+
+      const filled = SmartBuffer.wrap('\x01\x02');
+      filled.fill(0);
+      expect(filled.woffset).toEqual(2);
+      expect(filled.toDebug()).toEqual('<01 02]');
+    });
+
     it('slice', () => {
       const b = SmartBuffer.wrap('\x12\x34\x56');
       const b2 = b.slice(1, 3);


### PR DESCRIPTION
## Summary
- prevent SmartBuffer.fill from writing past the logical end
- add regression test covering default end behaviour

## Testing
- `yarn test` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.7.0/packages/yarnpkg-cli/bin/yarn.js)*